### PR TITLE
1.3.8.05【修复返回顶部时仍存在的闪烁问题】

### DIFF
--- a/src/components/layout/ReadmeSection.tsx
+++ b/src/components/layout/ReadmeSection.tsx
@@ -104,8 +104,10 @@ const ReadmeSection: React.FC<ReadmeSectionProps> = ({
         }
       }
 
-      // 导航后滚动到页面顶部
-      void scroll.scrollToTop();
+      // 避免渲染过程中闪烁
+      window.setTimeout(() => {
+        void scroll.scrollToTop();
+      }, 500);
     },
     [currentReadmeDir, findFileItemByPath, navigateTo, selectFile]
   );


### PR DESCRIPTION
1.3.8.03 版本抽取并复用 `scrollToTop()` 后，滚动过程中会出现图片内容不断闪烁的问题。

经排查发现，复用后  `src/components/preview/markdown/MarkdownPreview.tsx` 订阅 `ContentContext/
  PreviewContext`，在向上滚动过程中，返回顶部按钮状态更新导致父级重渲染，MUI 不断生成样式类导致 fadeIn 动画反复出现形成闪烁。

1.3.8.04 版本将内部链接解析和 `scrollToTop(）` 迁回 `src/components/layout/ReadmeSection.tsx` 以减少上下关系依赖，同时将 fadeIn 设为常量以避免动画重复触发，大体上减少了闪烁问题。但点击相对链接后，导航路径变动仍会触发 Markdown 容器渲染动画。

1.3.8.05 版本原先设想的修复方案有下列两个：
1. 渲染动画加载完毕触发回调
2. 为内部导航临时禁用动画

考虑到这个项目已经是一坨屎山，再写新的逻辑又不知道会触发哪个上下文的 bug，临时决定直接设置 500ms 的延时，在我的设备和网络环境下足够动画加载完毕再回到顶部，视觉上不会发生冲突。由此整个闪烁问题得以暂时修复。

> 其实我很少写 pr，现在写是为了**万一**在其它设备上仍存在闪烁，期末考完又忘记 bug 来源...