### PR TITLE
2.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "repo-viewer",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "repo-viewer",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-viewer",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/src/components/interactions/SearchDrawer/SearchResults.tsx
+++ b/src/components/interactions/SearchDrawer/SearchResults.tsx
@@ -132,7 +132,7 @@ export const SearchResults: React.FC<SearchResultsProps> = ({
 
   return (
     <>
-      {shouldVirtualize && items.length > 0 ? (
+      {shouldVirtualize ? (
         <Box sx={{ height: listHeight, width: "100%" }}>
           <AutoSizer
             renderProp={({ width, height }) => {

--- a/src/components/interactions/SearchDrawer/index.tsx
+++ b/src/components/interactions/SearchDrawer/index.tsx
@@ -114,7 +114,8 @@ export const SearchDrawer: React.FC<SearchDrawerProps> = ({ open, onClose }) => 
     return t("search.results.summary", {
       count: items.length,
       took: took.toFixed(1),
-      mode: mode === "code-search" ? t("search.results.codeMode") : t("search.results.apiMode"),
+      mode:
+        mode === "aggregated" ? t("search.results.aggregatedMode") : t("search.results.apiMode"),
     });
   }, [search.searchResult, t]);
 

--- a/src/components/preview/markdown/MarkdownPreview.tsx
+++ b/src/components/preview/markdown/MarkdownPreview.tsx
@@ -148,7 +148,7 @@ const MarkdownPreview = ({
         observerRef.current.disconnect();
       }
     };
-  }, [isLazyLoadEnabled, shouldRender]);
+  }, [isLazyLoadEnabled, shouldRender, hasReadmeContent]);
 
   // 监听主题切换事件
   useEffect(() => {

--- a/src/components/preview/markdown/components/MarkdownImage.tsx
+++ b/src/components/preview/markdown/components/MarkdownImage.tsx
@@ -111,6 +111,12 @@ export const MarkdownImage: React.FC<MarkdownImageProps> = ({
         const newSrc = handleImageError(stateKey, originalSrc, imageState, setIsImageFailed);
         if (newSrc !== null && newSrc.trim().length > 0 && newSrc !== stateKey) {
           event.currentTarget.src = newSrc;
+        } else if (newSrc === null) {
+          // 代理已切换，用新代理重新转换 URL 并重试
+          const retrySrc = transformImageSrc(src, previewingItem, currentBranch).imgSrc.trim();
+          if (retrySrc.length > 0 && retrySrc !== stateKey) {
+            event.currentTarget.src = retrySrc;
+          }
         }
       }}
     />

--- a/src/components/preview/markdown/utils/imageUtils.test.ts
+++ b/src/components/preview/markdown/utils/imageUtils.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createImageLoadingState, handleImageError } from "./imageUtils";
+
+const markProxyServiceFailedMock = vi.fn();
+const getCurrentProxyServiceMock = vi.fn();
+
+vi.mock("@/services/github", () => ({
+  GitHub: {
+    Proxy: {
+      markProxyServiceFailed: (...args: unknown[]) => markProxyServiceFailedMock(...args),
+      getCurrentProxyService: () => getCurrentProxyServiceMock(),
+    },
+  },
+}));
+
+const PROXIED_SRC = "https://gh-proxy.com/https://raw.githubusercontent.com/o/r/main/img.png";
+
+beforeEach(() => {
+  markProxyServiceFailedMock.mockReset();
+  getCurrentProxyServiceMock.mockReset();
+  vi.stubGlobal("window", {
+    setTimeout: (fn: () => void) => setTimeout(fn, 0) as unknown as number,
+    clearTimeout: (id: number) => clearTimeout(id as unknown as NodeJS.Timeout),
+  });
+});
+
+describe("handleImageError", () => {
+  it("marks the failed proxy and returns null when a different proxy is available", () => {
+    getCurrentProxyServiceMock.mockReturnValue("https://proxy-b.com");
+    const imageState = createImageLoadingState();
+    const setIsImageFailed = vi.fn();
+
+    const result = handleImageError(PROXIED_SRC, PROXIED_SRC, imageState, setIsImageFailed);
+
+    expect(markProxyServiceFailedMock).toHaveBeenCalledWith("https://gh-proxy.com");
+    expect(setIsImageFailed).toHaveBeenCalledWith(false);
+    expect(result).toBeNull();
+  });
+
+  it("falls back to the jsDelivr direct URL when no other proxy is available", () => {
+    getCurrentProxyServiceMock.mockReturnValue("https://gh-proxy.com");
+    const imageState = createImageLoadingState();
+    const setIsImageFailed = vi.fn();
+
+    const result = handleImageError(PROXIED_SRC, PROXIED_SRC, imageState, setIsImageFailed);
+
+    expect(markProxyServiceFailedMock).toHaveBeenCalledWith("https://gh-proxy.com");
+    expect(result).toContain("cdn.jsdelivr.net/gh");
+    expect(result).toContain("img.png");
+  });
+
+  it("tries the original source after a transformed URL fails", () => {
+    getCurrentProxyServiceMock.mockReturnValue("https://gh-proxy.com");
+    const imageState = createImageLoadingState();
+    const setIsImageFailed = vi.fn();
+
+    const result = handleImageError("https://proxy.example.com/x.png", "https://raw.example.com/img.png", imageState, setIsImageFailed);
+
+    expect(result).toBe("https://raw.example.com/img.png");
+  });
+});

--- a/src/components/preview/markdown/utils/imageUtils.test.ts
+++ b/src/components/preview/markdown/utils/imageUtils.test.ts
@@ -75,7 +75,12 @@ describe("handleImageError", () => {
     const imageState = createImageLoadingState();
     const setIsImageFailed = vi.fn();
 
-    const result = handleImageError("https://proxy.example.com/x.png", "https://raw.example.com/img.png", imageState, setIsImageFailed);
+    const result = handleImageError(
+      "https://proxy.example.com/x.png",
+      "https://raw.example.com/img.png",
+      imageState,
+      setIsImageFailed,
+    );
 
     expect(result).toBe("https://raw.example.com/img.png");
   });

--- a/src/components/preview/markdown/utils/imageUtils.test.ts
+++ b/src/components/preview/markdown/utils/imageUtils.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createImageLoadingState, handleImageError } from "./imageUtils";
+import { createImageLoadingState, handleImageError, tryDirectImageLoad } from "./imageUtils";
 
 const markProxyServiceFailedMock = vi.fn();
 const getCurrentProxyServiceMock = vi.fn();
@@ -13,14 +13,35 @@ vi.mock("@/services/github", () => ({
   },
 }));
 
+const getGithubConfigMock = vi.fn();
+vi.mock("@/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/config")>();
+  return {
+    ...actual,
+    getGithubConfig: () => getGithubConfigMock(),
+  };
+});
+
 const PROXIED_SRC = "https://gh-proxy.com/https://raw.githubusercontent.com/o/r/main/img.png";
 
 beforeEach(() => {
   markProxyServiceFailedMock.mockReset();
   getCurrentProxyServiceMock.mockReset();
+  getGithubConfigMock.mockReset();
+  getGithubConfigMock.mockReturnValue({ repoOwner: "CQUT-OpenProject", repoName: "Repo-Viewer" });
   vi.stubGlobal("window", {
     setTimeout: (fn: () => void) => setTimeout(fn, 0) as unknown as number,
     clearTimeout: (id: number) => clearTimeout(id as unknown as NodeJS.Timeout),
+  });
+});
+
+describe("tryDirectImageLoad", () => {
+  it("builds the jsDelivr URL from the configured repository", () => {
+    getGithubConfigMock.mockReturnValue({ repoOwner: "Royfor12", repoName: "Repo-Viewer" });
+
+    const result = tryDirectImageLoad(PROXIED_SRC);
+
+    expect(result).toBe("https://cdn.jsdelivr.net/gh/Royfor12/Repo-Viewer@main/img.png");
   });
 });
 

--- a/src/components/preview/markdown/utils/imageUtils.ts
+++ b/src/components/preview/markdown/utils/imageUtils.ts
@@ -1,3 +1,4 @@
+import { getGithubConfig } from "@/config";
 import { GitHub } from "@/services/github";
 import type { GitHubContent } from "@/types";
 import { logger } from "@/utils/logging/logger";
@@ -78,11 +79,7 @@ export const tryDirectImageLoad = (imgSrc: string): string | null => {
     }
 
     const proxy = "https://cdn.jsdelivr.net/gh";
-    const currentProxy = GitHub.Proxy.getCurrentProxyService();
-    const repoOwner = currentProxy.includes("Royfor12") ? "Royfor12" : "CQUT-OpenProject";
-    const repoName = currentProxy.includes("CQUT-Course-Guide-Sharing-Scheme")
-      ? "CQUT-Course-Guide-Sharing-Scheme"
-      : "Repo-Viewer";
+    const { repoOwner, repoName } = getGithubConfig();
     const newSrc = `${proxy}/${repoOwner}/${repoName}@main/${directPath}`;
     logger.info("尝试使用JSDelivr加载图片:", newSrc);
     return newSrc;

--- a/src/hooks/github/useContentLoading.ts
+++ b/src/hooks/github/useContentLoading.ts
@@ -85,12 +85,14 @@ export function useContentLoading(path: string, branch: string): ContentLoadingS
 
       try {
         const sourceTracker: { value: ContentSource } = { value: "network" };
+        const requestedPath = currentPathRef.current;
+        const requestedBranch = currentBranchRef.current;
 
         // 使用 requestManager 自动处理请求取消和防抖
         const data = await requestManager.request(
           "github-contents",
           (signal) =>
-            GitHub.Content.getContents(currentPathRef.current, signal, {
+            GitHub.Content.getContents(requestedPath, signal, {
               forceRefresh,
               onSource: (source) => {
                 sourceTracker.value = source;
@@ -98,6 +100,15 @@ export function useContentLoading(path: string, branch: string): ContentLoadingS
             }),
           { debounce: forceRefresh ? 0 : 100 },
         );
+
+        // 请求期间路径或分支已变化，丢弃过期响应，避免旧数据覆盖新路径
+        if (
+          currentPathRef.current !== requestedPath ||
+          currentBranchRef.current !== requestedBranch
+        ) {
+          logger.debug("路径或分支已变化，丢弃过期响应");
+          return;
+        }
 
         const filteredData = filterContents(data);
         const nextSignature = buildContentsSignature(filteredData);

--- a/src/hooks/github/useContentLoading.ts
+++ b/src/hooks/github/useContentLoading.ts
@@ -38,6 +38,7 @@ export function useContentLoading(path: string, branch: string): ContentLoadingS
   const lastSignatureRef = useRef<string>("");
   const forceRefreshRef = useRef<boolean>(false);
   const revalidateKeyRef = useRef<string | null>(null);
+  const skippedByThemeRef = useRef<boolean>(false);
 
   const buildContentsSignature = React.useCallback((data: GitHubContent[]): string => {
     if (data.length === 0) {
@@ -173,6 +174,7 @@ export function useContentLoading(path: string, branch: string): ContentLoadingS
   useEffect(() => {
     // 主题切换期间跳过内容重新加载
     if (isThemeChangingRef.current) {
+      skippedByThemeRef.current = true;
       logger.debug("主题切换中，跳过内容重新加载");
       return;
     }
@@ -182,6 +184,21 @@ export function useContentLoading(path: string, branch: string): ContentLoadingS
 
     void loadContents({ forceRefresh: shouldForceRefresh });
   }, [path, branch, refreshTrigger, loadContents, isThemeChangingRef]);
+
+  // 主题切换期间跳过的加载在切换结束后补跑，避免内容停留在旧路径
+  useEffect(() => {
+    const handleThemeChanged = (): void => {
+      if (skippedByThemeRef.current) {
+        skippedByThemeRef.current = false;
+        setRefreshTrigger((prev) => prev + 1);
+      }
+    };
+
+    window.addEventListener("theme:changed", handleThemeChanged);
+    return () => {
+      window.removeEventListener("theme:changed", handleThemeChanged);
+    };
+  }, []);
 
   const refresh = () => {
     forceRefreshRef.current = true;

--- a/src/hooks/github/useContentLoading.ts
+++ b/src/hooks/github/useContentLoading.ts
@@ -83,10 +83,11 @@ export function useContentLoading(path: string, branch: string): ContentLoadingS
         setError(null);
       }
 
+      const requestedPath = currentPathRef.current;
+      const requestedBranch = currentBranchRef.current;
+
       try {
         const sourceTracker: { value: ContentSource } = { value: "network" };
-        const requestedPath = currentPathRef.current;
-        const requestedBranch = currentBranchRef.current;
 
         // 使用 requestManager 自动处理请求取消和防抖
         const data = await requestManager.request(
@@ -155,7 +156,12 @@ export function useContentLoading(path: string, branch: string): ContentLoadingS
           setContents([]);
         }
       } finally {
-        if (shouldShowLoading) {
+        // 仅当仍是当前路径/分支时复位 loading，避免被取消的旧请求提前清除新请求的加载状态
+        if (
+          shouldShowLoading &&
+          currentPathRef.current === requestedPath &&
+          currentBranchRef.current === requestedBranch
+        ) {
           setLoading(false);
         }
       }

--- a/src/hooks/github/usePathManagement.ts
+++ b/src/hooks/github/usePathManagement.ts
@@ -8,6 +8,9 @@ import {
 import { logger } from "@/utils/logging/logger";
 import type { PathManagementState } from "./types";
 
+/** 刷新期间导航锁定的最长持续时间，防止请求挂起时导航被永久忽略 */
+const REFRESH_LOCK_TIMEOUT = 5000;
+
 /**
  * 路径管理 Hook
  *
@@ -60,6 +63,7 @@ export function usePathManagement(branch: string): PathManagementState {
   const currentBranchRef = useRef<string>(branch);
   const isRefreshInProgressRef = useRef(false);
   const refreshTargetPathRef = useRef<string | null>(null);
+  const refreshLockTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   currentPathRef.current = currentPath;
   currentBranchRef.current = branch;
 
@@ -161,7 +165,30 @@ export function usePathManagement(branch: string): PathManagementState {
 
   // 设置刷新状态（供其他 Hook 使用）
   const setRefreshState = (isRefreshing: boolean, targetPath?: string) => {
-    isRefreshInProgressRef.current = isRefreshing;
+    if (!isRefreshing) {
+      if (refreshLockTimeoutRef.current !== null) {
+        clearTimeout(refreshLockTimeoutRef.current);
+        refreshLockTimeoutRef.current = null;
+      }
+      isRefreshInProgressRef.current = false;
+      refreshTargetPathRef.current = targetPath ?? null;
+      return;
+    }
+
+    // 刷新请求可能挂起（fetch 无超时），加兜底解锁，避免导航被永久忽略
+    if (refreshLockTimeoutRef.current !== null) {
+      clearTimeout(refreshLockTimeoutRef.current);
+    }
+    refreshLockTimeoutRef.current = setTimeout(() => {
+      refreshLockTimeoutRef.current = null;
+      if (isRefreshInProgressRef.current) {
+        logger.warn("刷新路径锁定超时，自动解除");
+        isRefreshInProgressRef.current = false;
+        refreshTargetPathRef.current = null;
+      }
+    }, REFRESH_LOCK_TIMEOUT);
+
+    isRefreshInProgressRef.current = true;
     refreshTargetPathRef.current = targetPath ?? null;
   };
 

--- a/src/hooks/github/useRepoSearch/types.ts
+++ b/src/hooks/github/useRepoSearch/types.ts
@@ -1,7 +1,7 @@
 import type { GitHubContent } from "@/types";
 import type { CodeSearchResultItem } from "@/services/github/core/search";
 
-export type RepoSearchMode = "code-search" | "github-api";
+export type RepoSearchMode = "aggregated" | "github-api";
 
 export interface RepoSearchFilters {
   keyword: string;

--- a/src/hooks/github/useRepoSearch/useRepoSearch.ts
+++ b/src/hooks/github/useRepoSearch/useRepoSearch.ts
@@ -28,6 +28,7 @@ import type {
   UseRepoSearchOptions,
 } from "./types";
 import {
+  mergeSearchResults,
   normalizeSearchError,
   resolveBranchSelection,
   sanitizeBranchList,
@@ -290,11 +291,11 @@ export function useRepoSearch({
           throw codeSearchError;
         }
 
-        const seenPaths = new Set(codeItems.map((item) => item.path));
-        const items: RepoSearchItem[] = [
-          ...codeItems,
-          ...treesItems.filter((item) => !seenPaths.has(item.path)),
-        ];
+        const items: RepoSearchItem[] = mergeSearchResults(
+          codeItems,
+          treesItems,
+          trimmedDefaultBranch,
+        );
 
         return {
           mode: useCodeSearch ? "aggregated" : "github-api",

--- a/src/hooks/github/useRepoSearch/useRepoSearch.ts
+++ b/src/hooks/github/useRepoSearch/useRepoSearch.ts
@@ -1,11 +1,11 @@
 /**
  * @fileoverview 仓库搜索 Hook
  *
- * 提供 GitHub 仓库内容的搜索功能，采用合并执行策略：
- * 1. 默认分支：使用 GitHub Code Search API（内容 + 路径全文搜索，支持 CJK）
- * 2. 非默认分支：使用 GitHub Trees API 路径搜索（Code Search 仅索引默认分支）
+ * 提供 GitHub 仓库内容的搜索功能，采用聚合搜索策略：
+ * 1. 所有选中分支：并行使用 Trees API 匹配文件路径/文件名
+ * 2. 含默认分支时：额外并行 GitHub Code Search API（内容全文，仅索引默认分支）
  *
- * 结果按 Code Search 优先合并去重，Code Search 失败时保留 Trees 结果。
+ * 结果按 Code Search 优先合并去重；Code Search 失败或无索引时仍保留 Trees 路径结果。
  *
  * @module hooks/github/useRepoSearch/useRepoSearch
  */
@@ -47,8 +47,7 @@ interface RepoSearchInputFilters {
 /**
  * 仓库搜索 Hook
  *
- * 提供完整的仓库内容搜索功能，自动合并默认分支的 Code Search 结果
- * 与非默认分支的 Trees API 路径搜索结果。
+ * 提供完整的仓库聚合搜索功能，并行合并 Code Search 与 Trees API 结果。
  *
  * @param options - 搜索配置选项
  * @param options.currentBranch - 当前分支名称
@@ -235,48 +234,50 @@ export function useRepoSearch({
       const execution = await requestManager.request(SEARCH_REQUEST_KEY, async (signal) => {
         const trimmedDefaultBranch = defaultBranch.trim();
         const useCodeSearch = resolvedBranches.includes(trimmedDefaultBranch);
-        const nonDefaultBranches = resolvedBranches.filter(
-          (branch) => branch !== trimmedDefaultBranch,
-        );
 
         const treesPromise =
-          nonDefaultBranches.length > 0
+          resolvedBranches.length > 0
             ? GitHub.Search.searchMultipleBranchesWithTreesApi(
                 keyword,
-                nonDefaultBranches,
+                resolvedBranches,
                 pathPrefixRaw,
                 sanitizedExtensions,
                 signal,
               )
             : Promise.resolve([]);
 
-        let codeItems: RepoSearchCodeItem[] = [];
-        let codeSearchError: unknown = null;
-
-        if (useCodeSearch) {
-          try {
-            const results = await GitHub.Search.searchCode({
+        const codeSearchPromise = useCodeSearch
+          ? GitHub.Search.searchCode({
               keyword,
               branch: trimmedDefaultBranch,
               pathPrefix: pathPrefixRaw === "" ? undefined : pathPrefixRaw,
               extensions: sanitizedExtensions.length > 0 ? sanitizedExtensions : undefined,
               limit: DEFAULT_SEARCH_LIMIT,
               signal,
-            });
-            codeItems = results.map((item) => ({
-              ...item,
-              source: "code-search" as const,
-            }));
-          } catch (error) {
-            if (isAbortError(error)) {
-              throw error;
-            }
-            codeSearchError = error;
-            logger.warn(`[RepoSearch] Code Search 失败，回退到 Trees 结果: ${keyword}`, error);
-          }
-        }
+            })
+              .then((results) => ({
+                codeItems: results.map(
+                  (item): RepoSearchCodeItem => ({
+                    ...item,
+                    source: "code-search",
+                  }),
+                ),
+                codeSearchError: null as unknown,
+              }))
+              .catch((error: unknown) => {
+                if (isAbortError(error)) {
+                  throw error;
+                }
+                logger.warn(`[RepoSearch] Code Search 失败，保留 Trees 结果: ${keyword}`, error);
+                return { codeItems: [] as RepoSearchCodeItem[], codeSearchError: error };
+              })
+          : Promise.resolve({ codeItems: [] as RepoSearchCodeItem[], codeSearchError: null });
 
-        const branchResults = await treesPromise;
+        const [{ codeItems, codeSearchError }, branchResults] = await Promise.all([
+          codeSearchPromise,
+          treesPromise,
+        ]);
+
         const treesItems: RepoSearchApiItem[] = branchResults.flatMap(({ branch, results }) =>
           results.map((item) => ({
             ...item,
@@ -296,7 +297,7 @@ export function useRepoSearch({
         ];
 
         return {
-          mode: useCodeSearch ? "code-search" : "github-api",
+          mode: useCodeSearch ? "aggregated" : "github-api",
           items,
           took: performance.now() - startedAt,
           filters: {

--- a/src/hooks/github/useRepoSearch/utils.test.ts
+++ b/src/hooks/github/useRepoSearch/utils.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { normalizeSearchError, resolveBranchSelection, sanitizeExtensions } from "./utils";
+import type { RepoSearchApiItem, RepoSearchCodeItem } from "./types";
+import {
+  mergeSearchResults,
+  normalizeSearchError,
+  resolveBranchSelection,
+  sanitizeExtensions,
+} from "./utils";
 
 const createBranchContext = (branches: string[]) => {
   const availableBranches = new Set<string>();
@@ -16,6 +22,23 @@ const createBranchContext = (branches: string[]) => {
     branchOrder,
   };
 };
+
+const codeItem = (path: string): RepoSearchCodeItem => ({
+  branch: "main",
+  path,
+  name: path.split("/").pop() ?? path,
+  sha: "code-sha",
+  source: "code-search",
+});
+
+const treesItem = (path: string, branch: string): RepoSearchApiItem => ({
+  path,
+  name: path.split("/").pop() ?? path,
+  sha: `${branch}-sha`,
+  type: "file",
+  source: "github-api",
+  branch,
+} as RepoSearchApiItem);
 
 describe("useRepoSearch utils", () => {
   it("auto 模式会跟随 currentBranch 变化", () => {
@@ -95,5 +118,43 @@ describe("useRepoSearch utils", () => {
 
     expect(byCurrentBranch.effectiveBranches).toEqual(["feature"]);
     expect(byDefaultBranch.effectiveBranches).toEqual(["main"]);
+  });
+
+  it("默认分支的同名文件以 Code Search 结果优先去重", () => {
+    const result = mergeSearchResults(
+      [codeItem("src/util.ts")],
+      [treesItem("src/util.ts", "main")],
+      "main",
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.source).toBe("code-search");
+  });
+
+  it("非默认分支的同名文件不被 Code Search 结果误杀", () => {
+    const result = mergeSearchResults(
+      [codeItem("src/util.ts")],
+      [treesItem("src/util.ts", "develop")],
+      "main",
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({ branch: "develop", source: "github-api" });
+  });
+
+  it("无 Code Search 结果时保留全部 Trees 结果", () => {
+    const result = mergeSearchResults([], [treesItem("a.ts", "main"), treesItem("b.ts", "main")], "main");
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("不同非默认分支的同路径文件各自保留", () => {
+    const result = mergeSearchResults(
+      [codeItem("src/util.ts")],
+      [treesItem("src/util.ts", "develop"), treesItem("src/util.ts", "release")],
+      "main",
+    );
+
+    expect(result).toHaveLength(3);
   });
 });

--- a/src/hooks/github/useRepoSearch/utils.test.ts
+++ b/src/hooks/github/useRepoSearch/utils.test.ts
@@ -31,14 +31,15 @@ const codeItem = (path: string): RepoSearchCodeItem => ({
   source: "code-search",
 });
 
-const treesItem = (path: string, branch: string): RepoSearchApiItem => ({
-  path,
-  name: path.split("/").pop() ?? path,
-  sha: `${branch}-sha`,
-  type: "file",
-  source: "github-api",
-  branch,
-} as RepoSearchApiItem);
+const treesItem = (path: string, branch: string): RepoSearchApiItem =>
+  ({
+    path,
+    name: path.split("/").pop() ?? path,
+    sha: `${branch}-sha`,
+    type: "file",
+    source: "github-api",
+    branch,
+  }) as RepoSearchApiItem;
 
 describe("useRepoSearch utils", () => {
   it("auto 模式会跟随 currentBranch 变化", () => {
@@ -143,7 +144,11 @@ describe("useRepoSearch utils", () => {
   });
 
   it("无 Code Search 结果时保留全部 Trees 结果", () => {
-    const result = mergeSearchResults([], [treesItem("a.ts", "main"), treesItem("b.ts", "main")], "main");
+    const result = mergeSearchResults(
+      [],
+      [treesItem("a.ts", "main"), treesItem("b.ts", "main")],
+      "main",
+    );
 
     expect(result).toHaveLength(2);
   });

--- a/src/hooks/github/useRepoSearch/utils.ts
+++ b/src/hooks/github/useRepoSearch/utils.ts
@@ -1,4 +1,9 @@
-import type { RepoSearchError } from "./types";
+import type {
+  RepoSearchApiItem,
+  RepoSearchCodeItem,
+  RepoSearchError,
+  RepoSearchItem,
+} from "./types";
 
 export type BranchSelectionMode = "auto" | "manual";
 
@@ -125,4 +130,26 @@ export function normalizeSearchError(error: unknown): RepoSearchError {
     message,
     raw: error,
   } satisfies RepoSearchError;
+}
+
+/**
+ * 合并 Code Search 与 Trees API 搜索结果。
+ *
+ * Code Search 仅索引默认分支；默认分支的同名结果以 Code Search 优先，
+ * 其余分支的 Trees 结果全部保留，避免非默认分支的同名文件被误杀。
+ */
+export function mergeSearchResults(
+  codeItems: RepoSearchCodeItem[],
+  treesItems: RepoSearchApiItem[],
+  defaultBranch: string,
+): RepoSearchItem[] {
+  const seenPaths = new Set(codeItems.map((item) => item.path));
+  const trimmedDefaultBranch = defaultBranch.trim();
+
+  return [
+    ...codeItems,
+    ...treesItems.filter(
+      (item) => item.branch !== trimmedDefaultBranch || !seenPaths.has(item.path),
+    ),
+  ];
 }

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -144,8 +144,10 @@ export const useDownload = (
     logger.info("下载已取消");
 
     setTimeout(() => {
-      isCancelledRef.current = false;
-      dispatch({ type: "RESET_DOWNLOAD_STATE" });
+      if (abortControllerRef.current === null) {
+        isCancelledRef.current = false;
+        dispatch({ type: "RESET_DOWNLOAD_STATE" });
+      }
     }, 500);
   };
 

--- a/src/hooks/useFilePreview.ts
+++ b/src/hooks/useFilePreview.ts
@@ -116,8 +116,15 @@ export const useFilePreview = (
   }, [cancelActivePreviewRequest]);
 
   const loadTextLikeContent = React.useCallback(
-    async (item: GitHubContent, targetPath: string, kind: "markdown" | "text"): Promise<void> => {
-      updateUrlWithHistory(item.path.split("/").slice(0, -1).join("/"), item.path);
+    async (
+      item: GitHubContent,
+      targetPath: string,
+      kind: "markdown" | "text",
+      syncUrl = true,
+    ): Promise<void> => {
+      if (syncUrl) {
+        updateUrlWithHistory(item.path.split("/").slice(0, -1).join("/"), item.path);
+      }
       dispatch({ type: "SET_PREVIEW_LOADING", loading: true });
       const requestId = previewRequestIdRef.current + 1;
       previewRequestIdRef.current = requestId;
@@ -203,9 +210,9 @@ export const useFilePreview = (
         const isCurrentTarget = (): boolean => currentPreviewItemRef.current?.path === targetPath;
 
         if (isMarkdownFile(fileNameLower)) {
-          await loadTextLikeContent(item, targetPath, "markdown");
+          await loadTextLikeContent(item, targetPath, "markdown", trigger !== "history");
         } else if (isTextFile(item.name)) {
-          await loadTextLikeContent(item, targetPath, "text");
+          await loadTextLikeContent(item, targetPath, "text", trigger !== "history");
         } else if (isPdfFile(fileNameLower)) {
           try {
             await openPDFPreview({
@@ -230,7 +237,9 @@ export const useFilePreview = (
           }
         } else if (isImageFile(fileNameLower)) {
           const dirPath = item.path.split("/").slice(0, -1).join("/");
-          updateUrlWithHistory(dirPath, item.path);
+          if (trigger !== "history") {
+            updateUrlWithHistory(dirPath, item.path);
+          }
           if (!isCurrentTarget()) {
             return;
           }

--- a/src/hooks/useFilePreview.ts
+++ b/src/hooks/useFilePreview.ts
@@ -274,7 +274,7 @@ export const useFilePreview = (
   };
 
   useEffect(() => {
-    const handlePopState = (): void => {
+    const handlePopState = (event: PopStateEvent): void => {
       if (isHandlingNavigationRef.current) {
         return;
       }
@@ -282,7 +282,9 @@ export const useFilePreview = (
       try {
         const hasActivePreview = hasActivePreviewRef.current;
         const urlHasPreview = hasPreviewParam();
-        const previewPath = getPreviewFromUrl();
+        // history.state 中保存完整预览路径，优先使用以避免重名文件歧义
+        const statePreview = (event.state as { preview?: string } | null)?.preview;
+        const previewPath = statePreview?.split("/").pop() ?? getPreviewFromUrl();
 
         if (hasActivePreview && !urlHasPreview) {
           cancelActivePreviewRequest();
@@ -305,7 +307,8 @@ export const useFilePreview = (
               !(currentPreviewPath?.endsWith(`/${previewPath}`) ?? false))
           ) {
             if (findFileItemByPath !== undefined) {
-              const fileItem = findFileItemByPath(previewPath);
+              // state 中完整路径优先，hash 仅文件名时回退到文件名匹配
+              const fileItem = findFileItemByPath(statePreview ?? previewPath);
               if (fileItem !== undefined) {
                 currentPreviewItemRef.current = fileItem;
                 void selectFile(fileItem, "history");

--- a/src/hooks/useFilePreview.ts
+++ b/src/hooks/useFilePreview.ts
@@ -265,7 +265,7 @@ export const useFilePreview = (
   };
 
   useEffect(() => {
-    const handlePopState = (event: PopStateEvent): void => {
+    const handlePopState = (): void => {
       if (isHandlingNavigationRef.current) {
         return;
       }
@@ -309,7 +309,6 @@ export const useFilePreview = (
       } finally {
         isHandlingNavigationRef.current = false;
       }
-      void event;
     };
 
     window.addEventListener("popstate", handlePopState);

--- a/src/hooks/useThemeMode.ts
+++ b/src/hooks/useThemeMode.ts
@@ -57,12 +57,15 @@ const isFreshThemeData = (themeData: SavedThemeData): boolean =>
 
 const getInitialThemeState = (): { mode: PaletteMode; isAutoMode: boolean } => {
   const savedThemeData = readSavedThemeData();
-  if (savedThemeData !== null && isFreshThemeData(savedThemeData)) {
+  if (savedThemeData !== null) {
     const isAutoMode = savedThemeData.isAutoMode ?? true;
-    return {
-      mode: isAutoMode ? getSystemBasedMode() : savedThemeData.mode,
-      isAutoMode,
-    };
+    // 手动模式偏好应持久生效，不受过期时间限制
+    if (!isAutoMode && (savedThemeData.mode === "dark" || savedThemeData.mode === "light")) {
+      return { mode: savedThemeData.mode, isAutoMode };
+    }
+    if (isFreshThemeData(savedThemeData)) {
+      return { mode: getSystemBasedMode(), isAutoMode };
+    }
   }
 
   return {

--- a/src/locales/en-US/translations.json
+++ b/src/locales/en-US/translations.json
@@ -29,7 +29,8 @@
         "code": "Code"
       },
       "codeMode": "Code Mode",
-      "defaultBranchHint": "Content search only covers the default branch; other branches match file paths only"
+      "aggregatedMode": "Aggregated Search",
+      "defaultBranchHint": "Default branch: content and path search; other branches: path match only"
     },
     "input": {
       "placeholder": "Type to search",

--- a/src/locales/ja-JP/translations.json
+++ b/src/locales/ja-JP/translations.json
@@ -20,7 +20,8 @@
         "code": "コード"
       },
       "codeMode": "コード検索モード",
-      "defaultBranchHint": "コンテンツ検索はデフォルトブランチのみ対象です。他のブランチはファイルパスのみ一致します"
+      "aggregatedMode": "統合検索",
+      "defaultBranchHint": "デフォルトブランチはコンテンツとパスを検索；その他のブランチはパスのみ一致"
     },
     "input": {
       "placeholder": "検索キーワードを入力",

--- a/src/locales/zh-CN/translations.json
+++ b/src/locales/zh-CN/translations.json
@@ -20,7 +20,8 @@
         "code": "内容"
       },
       "codeMode": "内容搜索模式",
-      "defaultBranchHint": "内容搜索仅覆盖默认分支，其他分支仅匹配文件路径"
+      "aggregatedMode": "聚合搜索",
+      "defaultBranchHint": "默认分支同时检索内容与路径；非默认分支仅匹配文件路径"
     },
     "input": {
       "placeholder": "键入搜索内容",

--- a/src/services/github/RequestBatcher.ts
+++ b/src/services/github/RequestBatcher.ts
@@ -48,8 +48,6 @@ export class RequestBatcher {
 
   private readonly fingerprintCache = new Map<string, FingerprintData & { expiresAt: number }>();
 
-  private batchTimeout: ReturnType<typeof setTimeout> | null = null;
-  private readonly batchDelay = 20;
   private readonly maxRetries = 3;
   private readonly fingerprintTTL = 5 * 60 * 1000;
 
@@ -194,11 +192,6 @@ export class RequestBatcher {
       // 如果还没有这个键的请求队列，创建它
       if (!this.batchedRequests.has(requestKey)) {
         this.batchedRequests.set(requestKey, []);
-
-        // 设置超时以批量处理请求
-        this.batchTimeout ??= window.setTimeout(() => {
-          this.processBatch();
-        }, this.batchDelay);
       }
 
       // 添加到队列
@@ -317,13 +310,6 @@ export class RequestBatcher {
       this.batchedRequests.delete(requestKey);
       throw lastError;
     }
-  }
-
-  // 处理批处理队列
-  private processBatch(): void {
-    this.batchTimeout = null;
-
-    // 已经在enqueue中处理了所有队列
   }
 
   /**

--- a/src/services/github/cache/AdvancedCache.ts
+++ b/src/services/github/cache/AdvancedCache.ts
@@ -154,10 +154,9 @@ export class AdvancedCache<K extends string, V> {
    *
    * @param key - 缓存键
    * @param value - 要缓存的值
-   * @param version - 版本标识，默认为'1.0'
    * @returns Promise，设置完成后解析
    */
-  async set(key: K, value: V, version = "1.0"): Promise<void> {
+  async set(key: K, value: V): Promise<void> {
     const now = Date.now();
     const keyStr = key;
     await this.checkMemoryPressureAndCleanup();
@@ -169,7 +168,6 @@ export class AdvancedCache<K extends string, V> {
       accessCount: 1,
       lastAccess: now,
       size,
-      version,
     };
 
     this.cache.set(key, item);

--- a/src/services/github/cache/AdvancedCache.ts
+++ b/src/services/github/cache/AdvancedCache.ts
@@ -346,10 +346,35 @@ export class AdvancedCache<K extends string, V> {
       await this.delete(key);
     }
 
+    if (this.config.enablePersistence && this.config.useIndexedDB && this.db !== null) {
+      await this.cleanupExpiredPersistenceEntries();
+    }
+
     this.stats.lastCleanup = now;
 
     if (expiredKeys.length > 0) {
       logger.debug(`定期清理：删除了${expiredKeys.length.toString()}个过期缓存项`);
+    }
+  }
+
+  /**
+   * 清理持久层（IndexedDB）中的过期缓存项
+   *
+   * 内存LRU只保留最近使用的条目，被驱逐的条目仍存在于IndexedDB中，
+   * 只有被get触达时才会过期删除；此方法定期全量扫描，防止持久层无限膨胀。
+   */
+  private async cleanupExpiredPersistenceEntries(): Promise<void> {
+    try {
+      const items = await loadAllFromIndexedDB(this.db, this.config);
+      const now = Date.now();
+      for (const entry of items) {
+        const ttl = calculateTTL(this.config, entry.data);
+        if (now - entry.data.timestamp > ttl) {
+          await deleteItemFromIndexedDB(this.db, this.config, entry.key);
+        }
+      }
+    } catch (error: unknown) {
+      logger.debug("清理IndexedDB过期条目失败", error);
     }
   }
 
@@ -395,10 +420,10 @@ export class AdvancedCache<K extends string, V> {
       const items = await loadAllFromIndexedDB(this.db, this.config);
       let loadedCount = 0;
       const now = Date.now();
-      const defaultTTL = this.config.defaultTTL;
       items.forEach((entry) => {
         try {
-          if (now - entry.timestamp <= defaultTTL) {
+          const ttl = calculateTTL(this.config, entry.data);
+          if (now - entry.timestamp <= ttl) {
             this.cache.set(entry.key as K, entry.data);
             loadedCount += 1;
           }

--- a/src/services/github/cache/CacheManager.ts
+++ b/src/services/github/cache/CacheManager.ts
@@ -11,12 +11,23 @@ class CacheManagerImpl {
   private contentCache: AdvancedCache<string, unknown> | null = null;
   private fileCache: AdvancedCache<string, string> | null = null;
   private initialized = false;
+  private initializationPromise: Promise<void> | null = null;
 
-  public async initialize(): Promise<void> {
+  public initialize(): Promise<void> {
     if (this.initialized) {
-      return;
+      return Promise.resolve();
     }
 
+    if (this.initializationPromise === null) {
+      this.initializationPromise = this.initializeImpl().finally(() => {
+        this.initializationPromise = null;
+      });
+    }
+
+    return this.initializationPromise;
+  }
+
+  private async initializeImpl(): Promise<void> {
     try {
       const [contentCache, fileCache] = await Promise.all([
         (async () => {

--- a/src/services/github/cache/CacheManager.ts
+++ b/src/services/github/cache/CacheManager.ts
@@ -18,11 +18,9 @@ class CacheManagerImpl {
       return Promise.resolve();
     }
 
-    if (this.initializationPromise === null) {
-      this.initializationPromise = this.initializeImpl().finally(() => {
-        this.initializationPromise = null;
-      });
-    }
+    this.initializationPromise ??= this.initializeImpl().finally(() => {
+      this.initializationPromise = null;
+    });
 
     return this.initializationPromise;
   }

--- a/src/services/github/cache/CacheTypes.ts
+++ b/src/services/github/cache/CacheTypes.ts
@@ -43,5 +43,4 @@ export interface CacheItemMeta {
   accessCount: number;
   lastAccess: number;
   size: number;
-  version: string;
 }

--- a/src/services/github/core/content/cacheKeys.ts
+++ b/src/services/github/core/content/cacheKeys.ts
@@ -1,10 +1,9 @@
-import type { GitHubContent } from "@/types";
 import { hashStringSync } from "@/utils/crypto/hashUtils";
 
 /**
- * 缓存键与版本号工具。
+ * 缓存键工具。
  *
- * @remarks 统一封装目录/文件内容的缓存键生成规则以及版本签名算法，确保不同模块之间保持一致性。
+ * @remarks 统一封装目录/文件内容的缓存键生成规则，确保不同模块之间保持一致性。
  */
 
 /**
@@ -19,44 +18,4 @@ export function buildContentsCacheKey(path: string, branch: string): string {
   const keyString = `${branch}:${normalizedPath}`;
   const hash = hashStringSync(keyString);
   return `content:v2:${hash}`;
-}
-
-/**
- * 生成内容列表的缓存版本标识。
- *
- * @param path - 目录路径
- * @param branch - Git 分支名
- * @param contents - 内容数组
- * @returns 内容版本标识
- */
-export function generateContentVersion(
-  path: string,
-  branch: string,
-  contents: GitHubContent[],
-): string {
-  const contentSignature = contents
-    .map((item) => {
-      const identifier = item.sha !== "" ? item.sha : (item.size?.toString() ?? "unknown");
-      return `${item.name}-${identifier}`;
-    })
-    .join("|");
-
-  const versionString = `${branch}:${path}:${contentSignature}:${Date.now().toString()}`;
-  const hash = hashStringSync(versionString);
-  return `v_${hash}`;
-}
-
-/**
- * 生成文件内容的缓存版本标识。
- *
- * @param fileUrl - 文件 URL
- * @param content - 文件内容
- * @returns 文件版本标识
- */
-export function generateFileVersion(fileUrl: string, content: string): string {
-  const contentLength = content.length;
-  const timestamp = Date.now();
-  const versionString = `${fileUrl}:${contentLength.toString()}:${timestamp.toString()}`;
-  const hash = hashStringSync(versionString);
-  return `fv_${hash}`;
 }

--- a/src/services/github/core/content/cacheState.test.ts
+++ b/src/services/github/core/content/cacheState.test.ts
@@ -8,11 +8,6 @@ vi.mock("../../cache/CacheManager", () => ({
   },
 }));
 
-import {
-  ensureCacheInitialized,
-  isCacheAvailable,
-} from "./cacheState";
-
 describe("ensureCacheInitialized", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/src/services/github/core/content/cacheState.test.ts
+++ b/src/services/github/core/content/cacheState.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const initializeMock = vi.fn();
+
+vi.mock("../../cache/CacheManager", () => ({
+  CacheManager: {
+    initialize: () => initializeMock(),
+  },
+}));
+
+import {
+  ensureCacheInitialized,
+  isCacheAvailable,
+} from "./cacheState";
+
+describe("ensureCacheInitialized", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    initializeMock.mockReset();
+  });
+
+  const load = async (): Promise<typeof import("./cacheState")> => import("./cacheState");
+
+  it("shares a single initialization across concurrent callers", async () => {
+    let resolveInit: (() => void) | undefined;
+    initializeMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveInit = resolve;
+        }),
+    );
+
+    const mod = await load();
+    const first = mod.ensureCacheInitialized();
+    const second = mod.ensureCacheInitialized();
+
+    resolveInit?.();
+    await Promise.all([first, second]);
+
+    expect(initializeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries initialization after a failure and becomes available on success", async () => {
+    initializeMock.mockRejectedValueOnce(new Error("boom"));
+    const mod = await load();
+
+    await mod.ensureCacheInitialized();
+    expect(mod.isCacheAvailable()).toBe(false);
+
+    initializeMock.mockResolvedValueOnce(undefined);
+    await mod.ensureCacheInitialized();
+    expect(mod.isCacheAvailable()).toBe(true);
+    expect(initializeMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up permanently after reaching the maximum attempt count", async () => {
+    initializeMock.mockRejectedValue(new Error("boom"));
+    const mod = await load();
+
+    await mod.ensureCacheInitialized();
+    await mod.ensureCacheInitialized();
+    await mod.ensureCacheInitialized();
+    await mod.ensureCacheInitialized();
+
+    expect(initializeMock).toHaveBeenCalledTimes(3);
+    expect(mod.isCacheAvailable()).toBe(false);
+  });
+
+  it("does not initialize again once available", async () => {
+    initializeMock.mockResolvedValue(undefined);
+    const mod = await load();
+
+    await mod.ensureCacheInitialized();
+    await mod.ensureCacheInitialized();
+
+    expect(initializeMock).toHaveBeenCalledTimes(1);
+    expect(mod.isCacheAvailable()).toBe(true);
+  });
+});

--- a/src/services/github/core/content/cacheState.ts
+++ b/src/services/github/core/content/cacheState.ts
@@ -53,11 +53,9 @@ export async function ensureCacheInitialized(): Promise<void> {
     return;
   }
 
-  if (initializationPromise === null) {
-    initializationPromise = initializeCache().finally(() => {
-      initializationPromise = null;
-    });
-  }
+  initializationPromise ??= initializeCache().finally(() => {
+    initializationPromise = null;
+  });
 
   await initializationPromise;
 }

--- a/src/services/github/core/content/cacheState.ts
+++ b/src/services/github/core/content/cacheState.ts
@@ -3,7 +3,6 @@ import { logger } from "@/utils/logging/logger";
 import { SmartCache } from "@/utils/cache/SmartCache";
 
 import { CacheManager } from "../../cache/CacheManager";
-import { generateContentVersion, generateFileVersion } from "./cacheKeys";
 
 /**
  * 缓存状态管理模块
@@ -115,21 +114,16 @@ export async function getCachedFileContent(cacheKey: string): Promise<string | n
  * 如果主缓存不可用，则回退到内存缓存以保证功能可用性。
  *
  * @param cacheKey - 目录缓存键
- * @param path - 目录路径
- * @param branch - Git 分支名
  * @param contents - 目录内容数组
  * @returns Promise<void>
  */
 export async function storeDirectoryContents(
   cacheKey: string,
-  path: string,
-  branch: string,
   contents: GitHubContent[],
 ): Promise<void> {
   if (cacheAvailable) {
-    const version = generateContentVersion(path, branch, contents);
     const contentCache = CacheManager.getContentCache();
-    await contentCache.set(cacheKey, contents, version);
+    await contentCache.set(cacheKey, contents);
     return;
   }
 
@@ -140,19 +134,13 @@ export async function storeDirectoryContents(
  * 写入文件内容缓存，逻辑同上。
  *
  * @param cacheKey - 文件缓存键
- * @param fileUrl - 文件 URL
  * @param content - 文件内容
  * @returns Promise<void>
  */
-export async function storeFileContent(
-  cacheKey: string,
-  fileUrl: string,
-  content: string,
-): Promise<void> {
+export async function storeFileContent(cacheKey: string, content: string): Promise<void> {
   if (cacheAvailable) {
-    const version = generateFileVersion(fileUrl, content);
     const fileCache = CacheManager.getFileCache();
-    await fileCache.set(cacheKey, content, version);
+    await fileCache.set(cacheKey, content);
     return;
   }
 

--- a/src/services/github/core/content/cacheState.ts
+++ b/src/services/github/core/content/cacheState.ts
@@ -27,6 +27,11 @@ let initializationAttempts = 0;
 const MAX_INIT_ATTEMPTS = 3;
 
 /**
+ * 进行中的初始化Promise，并发调用方共享同一次初始化。
+ */
+let initializationPromise: Promise<void> | null = null;
+
+/**
  * 判断当前是否可以使用主缓存。
  *
  * @returns 主缓存是否可用
@@ -38,7 +43,8 @@ export function isCacheAvailable(): boolean {
 /**
  * 确保缓存系统已初始化。
  *
- * 失败时会自动降级到内存缓存，最多尝试三次以避免无限重试。
+ * 并发调用共享同一次初始化；失败时自动降级到内存缓存并允许后续重试，
+ * 最多尝试 MAX_INIT_ATTEMPTS 次以避免无限重试。
  *
  * @returns Promise<void>
  */
@@ -47,6 +53,16 @@ export async function ensureCacheInitialized(): Promise<void> {
     return;
   }
 
+  if (initializationPromise === null) {
+    initializationPromise = initializeCache().finally(() => {
+      initializationPromise = null;
+    });
+  }
+
+  await initializationPromise;
+}
+
+async function initializeCache(): Promise<void> {
   if (initializationAttempts >= MAX_INIT_ATTEMPTS) {
     logger.warn("ContentCache: 已达到最大初始化尝试次数，使用内存降级缓存");
     cacheInitialized = true;
@@ -67,9 +83,6 @@ export async function ensureCacheInitialized(): Promise<void> {
       `ContentCache: 缓存系统初始化失败（尝试 ${initializationAttempts.toString()}/${MAX_INIT_ATTEMPTS.toString()}），使用内存降级缓存`,
       cause,
     );
-
-    cacheInitialized = true;
-    cacheAvailable = false;
 
     if (import.meta.env.DEV) {
       logger.error("缓存初始化失败详情:", cause);

--- a/src/services/github/core/content/hydrationStore.ts
+++ b/src/services/github/core/content/hydrationStore.ts
@@ -266,7 +266,7 @@ export async function consumeHydratedDirectory(
   }
 
   initialDirectoryStore.delete(key);
-  await storeDirectoryContents(cacheKey, path, branch, contents);
+  await storeDirectoryContents(cacheKey, contents);
   cleanupInitialHydrationStateIfEmpty();
   logger.debug(`ContentHydration: 使用首屏注水目录数据 -> ${path === "" ? "/" : path}`);
   return contents;
@@ -301,7 +301,7 @@ export async function consumeHydratedFile(
   }
 
   initialFileStore.delete(key);
-  await storeFileContent(cacheKey, fileUrl, entry.content);
+  await storeFileContent(cacheKey, entry.content);
   cleanupInitialHydrationStateIfEmpty();
   logger.debug(`ContentHydration: 使用首屏注水文件数据 -> ${path}`);
   return entry.content;

--- a/src/services/github/core/content/service.ts
+++ b/src/services/github/core/content/service.ts
@@ -151,7 +151,7 @@ export async function getContents(
       excludeFiles: [...INITIAL_CONTENT_EXCLUDE_FILES],
     });
 
-    await storeDirectoryContents(cacheKey, path, branch, contents);
+    await storeDirectoryContents(cacheKey, contents);
     options?.onSource?.("network");
 
     return contents;
@@ -225,7 +225,7 @@ export async function getFileContent(fileUrl: string, signal?: AbortSignal): Pro
       content = await fetchTextByUrl(serverApiUrl);
     }
 
-    await storeFileContent(cacheKey, fileUrl, content);
+    await storeFileContent(cacheKey, content);
 
     return content;
   } catch (unknownError) {

--- a/src/services/github/core/search/treesSearch.ts
+++ b/src/services/github/core/search/treesSearch.ts
@@ -90,10 +90,7 @@ async function searchBranchWithTreesApi(
         ? itemPath.slice(itemPath.lastIndexOf("/") + 1)
         : itemPath;
 
-      if (
-        !fileName.toLowerCase().includes(normalizedSearchTerm) &&
-        !itemPath.toLowerCase().includes(normalizedSearchTerm)
-      ) {
+      if (!itemPath.toLowerCase().includes(normalizedSearchTerm)) {
         continue;
       }
 

--- a/src/shared/tokenRotator.test.ts
+++ b/src/shared/tokenRotator.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TokenRotator } from "./tokenRotator";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("TokenRotator", () => {
+  it("rotates through tokens and skips failed ones", () => {
+    const rotator = new TokenRotator();
+    rotator.setTokens(["a", "b", "c"]);
+    rotator.markTokenFailed("b");
+
+    expect(rotator.getNextToken()).toBe("c");
+    expect(rotator.getNextToken()).toBe("a");
+    expect(rotator.getNextToken()).toBe("c");
+  });
+
+  it("re-admits a failed token after the backoff window", () => {
+    vi.useFakeTimers();
+    const rotator = new TokenRotator();
+    rotator.setTokens(["a", "b"]);
+    rotator.markTokenFailed("a");
+
+    expect(rotator.isFailed("a")).toBe(true);
+    expect(rotator.getNextToken()).toBe("b");
+
+    vi.advanceTimersByTime(300001);
+    expect(rotator.isFailed("a")).toBe(false);
+    expect(rotator.getNextToken()).toBe("a");
+    expect(rotator.getNextToken()).toBe("b");
+  });
+
+  it("returns empty string when every token is currently failed", () => {
+    vi.useFakeTimers();
+    const rotator = new TokenRotator();
+    rotator.setTokens(["a"]);
+    rotator.markTokenFailed("a");
+
+    expect(rotator.getNextToken()).toBe("");
+  });
+});

--- a/src/shared/tokenRotator.ts
+++ b/src/shared/tokenRotator.ts
@@ -2,9 +2,12 @@
  * Shared multi-token rotator for GitHub PATs (client + api).
  */
 export class TokenRotator {
+  /** 失败退避时长，与 TokenManager.BACKOFF_DURATION 保持一致 */
+  private static readonly FAILURE_BACKOFF_MS = 300000;
+
   private tokens: string[] = [];
   private currentIndex = 0;
-  private failedTokens = new Set<string>();
+  private failedTokens = new Map<string, number>();
 
   public setTokens(tokens: string[]): void {
     this.tokens = [...new Set(tokens.map((t) => t.trim()).filter((t) => t.length > 0))];
@@ -32,7 +35,7 @@ export class TokenRotator {
     while (attempts < this.tokens.length) {
       this.currentIndex = (this.currentIndex + 1) % this.tokens.length;
       const token = this.tokens[this.currentIndex];
-      if (token === undefined || token.length === 0 || this.failedTokens.has(token)) {
+      if (token === undefined || token.length === 0 || this.isFailed(token)) {
         attempts += 1;
         continue;
       }
@@ -44,12 +47,20 @@ export class TokenRotator {
 
   public markTokenFailed(token: string): void {
     if (token.length > 0) {
-      this.failedTokens.add(token);
+      this.failedTokens.set(token, Date.now());
     }
   }
 
   public isFailed(token: string): boolean {
-    return this.failedTokens.has(token);
+    const failedAt = this.failedTokens.get(token);
+    if (failedAt === undefined) {
+      return false;
+    }
+    if (Date.now() - failedAt >= TokenRotator.FAILURE_BACKOFF_MS) {
+      this.failedTokens.delete(token);
+      return false;
+    }
+    return true;
   }
 
   public hasTokens(): boolean {

--- a/src/utils/download/folderZipPipeline.test.ts
+++ b/src/utils/download/folderZipPipeline.test.ts
@@ -160,6 +160,58 @@ describe("downloadFolderAsZip", () => {
     expect(decoder.decode(unzipped["docs/kept.txt"])).toBe("kept");
   });
 
+  it("continues after a mid-stream failure and still produces a valid archive with subsequent files", async () => {
+    const saveAsImpl = vi.fn();
+    const onFileError = vi.fn();
+    const streamError = new Error("connection dropped");
+    const failingReader = {
+      read: vi
+        .fn()
+        .mockResolvedValueOnce({ done: false, value: encoder.encode("partial-") })
+        .mockRejectedValueOnce(streamError),
+      cancel: vi.fn(async () => {}),
+      releaseLock: vi.fn(),
+    };
+    const fetchImpl = vi.fn(async (url: RequestInfo | URL) => {
+      const target = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+
+      if (target.includes("broken")) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          body: { getReader: () => failingReader },
+        } as unknown as Response;
+      }
+
+      return createStreamResponse(["kept"]);
+    });
+
+    await downloadFolderAsZip({
+      files: [
+        { path: "docs/broken.txt", url: "https://example.com/broken.txt" },
+        { path: "docs/kept.txt", url: "https://example.com/kept.txt" },
+      ],
+      signal: new AbortController().signal,
+      archiveName: "midstream.zip",
+      fetchImpl,
+      saveAsImpl,
+      showSaveFilePickerImpl: null,
+      onFileError,
+    });
+
+    expect(onFileError).toHaveBeenCalledTimes(1);
+    expect(onFileError).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "docs/broken.txt" }),
+      streamError,
+    );
+    expect(saveAsImpl).toHaveBeenCalledTimes(1);
+
+    const [savedBlob] = saveAsImpl.mock.calls[0] as [Blob, string];
+    const unzipped = unzipSync(new Uint8Array(await savedBlob.arrayBuffer()));
+    expect(decoder.decode(unzipped["docs/kept.txt"])).toBe("kept");
+  });
+
   it("aborts the active reader and sink when cancellation happens mid-stream", async () => {
     const abortController = new AbortController();
     const cancel = vi.fn(async () => {});

--- a/src/utils/download/folderZipPipeline.ts
+++ b/src/utils/download/folderZipPipeline.ts
@@ -268,6 +268,16 @@ const appendFileToZip = async (
       // Ignore reader cancellation failures during cleanup.
     }
 
+    if (!isAbortError(error)) {
+      try {
+        // 残缺条目必须 finalize，否则 fflate 会卡住后续所有文件输出且不写中央目录
+        zipEntry.push(new Uint8Array(0), true);
+        await writer.flush();
+      } catch {
+        // 保留原始错误，finalize 失败时 zip 回调会另行上报。
+      }
+    }
+
     throw error;
   } finally {
     reader.releaseLock();

--- a/src/utils/sorting/contentSorting.test.ts
+++ b/src/utils/sorting/contentSorting.test.ts
@@ -36,4 +36,9 @@ describe("contentSorting", () => {
     expect(getContentFirstLetter(createContent("Équipe.txt", "file"))).toBe("E");
     expect(getContentFirstLetter(createContent("Álvaro.md", "file"))).toBe("A");
   });
+
+  it("returns a single-letter index even when uppercasing expands the character", () => {
+    expect(getContentFirstLetter(createContent("ßetrieb.md", "file"))).toBe("S");
+    expect(getContentFirstLetter(createContent("İstanbul.md", "file"))).toBe("I");
+  });
 });

--- a/src/utils/sorting/contentSorting.ts
+++ b/src/utils/sorting/contentSorting.ts
@@ -85,7 +85,8 @@ export function getContentFirstLetter(content: GitHubContent): string {
   }
 
   const normalized = firstCharRaw.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
-  const firstChar = normalized.toUpperCase();
+  // toUpperCase 可能扩展字符（如 ß -> SS），只保留首字符作为索引键
+  const firstChar = normalized.toUpperCase().charAt(0);
 
   // 检查是否为字母
   if (/[A-Z]/.test(firstChar)) {


### PR DESCRIPTION
## Summary
- Search: run Code Search and Trees API in parallel; keep non-default branch hits when merging results; restore previews via full path from history state
- Cache: share initialization across concurrent callers and retry on failure; sweep expired IndexedDB entries; unify TTL checks; remove dead version tagging
- Loading & navigation: discard stale directory responses; keep loading state consistent across cancelled requests; auto-release refresh navigation lock on stall; re-run loads skipped during theme transitions
- Download: finalize broken zip entries so mid-stream failures keep the archive valid; fix cancellation races; restore token rotation after backoff
- Images & previews: retry through the switched proxy; build jsDelivr fallback from the configured repo; re-arm lazy-load observer; persist manual theme choice past the freshness window
- Minor: single-letter alphabet index keys, dead code cleanup, lint fixes

## Test plan
- [x] `vp check` (0 errors, 0 warnings)
- [x] `vp test` (103 passed)
